### PR TITLE
[HAL] Correctly serialse self link

### DIFF
--- a/polls/resource.py
+++ b/polls/resource.py
@@ -147,7 +147,7 @@ def to_hal(resource):
             href = related_resource.get_uri()
             links[relation] = {'href': href}
 
-    links['self'] = resource.get_uri()
+    links['self'] = {'href': resource.get_uri()}
 
     document['_links'] = links
     if len(embed):


### PR DESCRIPTION
Links in HAL are a JSON object with a href to the URI and not a string representing the URI. This pull request fixes that mistake.

![I've made a mistake.](http://media.giphy.com/media/5PiIuCHlkQ58Y/giphy.gif)