### PR TITLE
[CirleCI] Override default tests runner

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,5 +3,5 @@ dependencies:
     - npm install -g dredd
 
 test:
-  post:
+  override:
     - ./scripts/dredd


### PR DESCRIPTION
Otherwise Circle CI will run it's default Django runner which for some reason fails (trying to move a file that doesn't exist). Seems like a Circle CI bug.

![screen shot 2015-04-14 at 18 32 28](https://cloud.githubusercontent.com/assets/44164/7150792/ab6860de-e2d4-11e4-8e61-54e4336aa3a8.png)