### PR TITLE
Prevent a user creating two identical questions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,13 @@
+machine:
+  environment:
+    DATABASE_URL: postgres://ubuntu:@127.0.0.1:5432/circle_test
+
 dependencies:
   post:
     - npm install -g dredd
 
 test:
-  override:
+  pre:
+    - python manage.py migrate
+  post:
     - ./scripts/dredd

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -19,3 +19,28 @@ class CreateQuestionTestCase(TestCase):
         self.assertEqual(choice_a.choice_text, 'A')
         self.assertEqual(choice_b.choice_text, 'B')
         self.assertEqual(choice_c.choice_text, 'C')
+
+    def test_creating_duplicate_question_doesnt_duplicate(self):
+        """
+        Creating two identical questions should result in a single question
+        """
+
+        response1 = self.client.post('/questions', '{"question": "Test Question?", "choices": ["A", "B", "C"]}', content_type='application/json')
+        response2 = self.client.post('/questions', '{"question": "Test Question?", "choices": ["A", "B", "C"]}', content_type='application/json')
+
+        self.assertEqual(response1.status_code, 201)
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(len(Question.objects.all()), 1)
+
+    def test_creating_similar_questions_creates(self):
+        """
+        Creating two similar questions should result in two questions
+        """
+
+        response1 = self.client.post('/questions', '{"question": "Test Question?", "choices": ["A", "B", "C"]}', content_type='application/json')
+        response2 = self.client.post('/questions', '{"question": "Test Question?", "choices": ["D", "E", "F"]}', content_type='application/json')
+
+        self.assertEqual(response1.status_code, 201)
+        self.assertEqual(response2.status_code, 201)
+        self.assertEqual(len(Question.objects.all()), 2)
+

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -1,0 +1,21 @@
+from django.test import TestCase, Client
+
+from polls.models import Question
+
+
+class CreateQuestionTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_creating_question(self):
+        response = self.client.post('/questions', '{"question": "Test Question?", "choices": ["A", "B", "C"]}', content_type='application/json')
+
+        self.assertEqual(response.status_code, 201)
+
+        question = Question.objects.all()[0]
+        self.assertEqual(question.question_text, 'Test Question?')
+
+        choice_a, choice_b, choice_c = question.choice_set.order_by('choice_text')
+        self.assertEqual(choice_a.choice_text, 'A')
+        self.assertEqual(choice_b.choice_text, 'B')
+        self.assertEqual(choice_c.choice_text, 'C')


### PR DESCRIPTION
This adds tests, and logic so that when someone tries to create an identical question with the same choices using the API. We will no longer create a duplicate and instead return the same question as before.

Mostly due to many people hitting "try-it" on Apiary for the default question.