### PR TITLE
Use LaunchDarkly when API Key is available

### DIFF
--- a/polls/features.py
+++ b/polls/features.py
@@ -1,0 +1,37 @@
+import os
+from hashlib import sha1
+
+try:
+    from ldclient import LDClient
+except ImportError:
+    LDClient = None
+
+from polls.settings import CAN_CREATE_QUESTION, CAN_DELETE_QUESTION, CAN_VOTE_QUESTION
+
+if LDClient and 'LD_API_KEY' in os.environ:
+    ld_client = LDClient(os.environ['LD_API_KEY'])
+else:
+    ld_client = None
+
+
+def is_feature_enabled(feature_key, request, default=False):
+    if ld_client:
+        ip_address = request.META.get('REMOTE_ADDR', 'unknown')
+        key = sha1(ip_address).hexdigest()
+        user = {'key': key}
+        return ld_client.toggle(feature_key, user, default)
+
+    return default
+
+
+def can_create_question(request):
+    return is_feature_enabled('question.create', request, CAN_CREATE_QUESTION)
+
+
+def can_delete_question(request):
+    return is_feature_enabled('question.delete', request, CAN_DELETE_QUESTION)
+
+
+def can_vote_choice(request):
+    return is_feature_enabled('choice.vote', request, CAN_VOTE_QUESTION)
+

--- a/polls/resource.py
+++ b/polls/resource.py
@@ -90,6 +90,7 @@ class CollectionResource(Resource):
         def to_resource(obj):
             resource = self.resource()
             resource.obj = obj
+            resource.request = self.request
             return resource
 
         return map(to_resource, self.get_objects())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,15 @@
+CacheControl==0.10.2
+Django==1.7.5
+certifi==2015.04.28
 dj-database-url==0.3.0
 dj-static==0.0.6
-Django==1.7.5
+django-cors-headers==1.0.0
 django-toolbelt==0.0.1
+future==0.14.3
 gunicorn==19.2.1
+ldclient-py==0.16.2
 negotiator==1.0.0
 psycopg2==2.6
+requests==2.4.0
 static3==0.5.1
-django-cors-headers==1.0.0
+wsgiref==0.1.2


### PR DESCRIPTION
This pull request brings support for LaunchDarkly. It's not enabled by default, and it's only available once you configure `LD_API_KEY` in your environment. It will use the following keys from LaunchDarkly (you probably want to add these your own account):

- `question.create`
- `question.delete`
- `choice.vote`

The client will send the user's IP address, hashed via SHA1 to launch darkly as the user. Allowing you to rollout features for individual IPs etc.

/cc @fosrias 