### PR TITLE
Add an allow header to JSON responses

### DIFF
--- a/polls/resource.py
+++ b/polls/resource.py
@@ -65,12 +65,18 @@ class Resource(View):
         response = HttpResponse(json.dumps(handler(self)), content_type)
 
         if str(content_type) == 'application/json':
+            # Add a Link header
             can_embed_relation = lambda relation: not self.can_embed(relation[0])
             relations = filter(can_embed_relation, self.get_relations().items())
             relation_to_link = lambda relation: '<{}>; rel="{}"'.format(relation[1].get_uri(), relation[0])
             links = map(relation_to_link, relations)
             if len(links) > 0:
                 response['Link'] = ', '.join(links)
+
+        if str(content_type) != 'application/vnd.siren+json':
+            # Add an Allow header
+            methods = ['HEAD', 'GET'] + map(lambda a: a.method, self.get_actions().values())
+            response['allow'] = ', '.join(methods)
 
         return response
 

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -1,7 +1,22 @@
 from django.test import TestCase, Client
+from django.http import HttpRequest
 
+from polls.resource import Action, Resource
 from polls.views import QuestionResource
 from polls.models import Question, Choice, Vote
+
+
+class ResourceTestCase(TestCase):
+    def test_json_includes_allow_header(self):
+        class TestAllowActionResource(Resource):
+            def get_actions(self):
+                return { 'delete': Action(method='DELETE', attributes=None) }
+
+        request = HttpRequest()
+        request.META['HTTP_ACCEPT'] = 'application/json'
+        response = TestAllowActionResource().get(request)
+
+        self.assertEqual(response['Allow'], 'HEAD, GET, DELETE')
 
 
 class CreateQuestionTestCase(TestCase):


### PR DESCRIPTION
This pull request adds an "allow" header showing the available methods that are applicable to the resource when not using Siren. This allows you to determine available transitions when using the JSON or HAL content types which didn't offer these before.

Example usage can be found in Hyperdrive: https://github.com/the-hypermedia-project/Hyperdrive/pull/15