### PR TITLE
Improve installation instructions on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ $ heroku config:set POLLS_CAN_DELETE_QUESTION=false
 
 You can configure a development environment with the following:
 
+**NOTE**: *These steps assume you have Python along with [pip](https://pip.pypa.io/en/latest/installing.html) and [virtualenv](https://virtualenv.pypa.io/en/latest/installation.html) installed.*
+
 ```bash
 $ virtualenv venv
 $ source venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ $ python manage.py test
 $ python manage.py runserver
 ```
 
+### Running dredd
+
+Providing [dredd](http://dredd.readthedocs.org/en/latest/) has been
+installed, you can run the following to run dredd against the Polls API:
+
+```bash
+$ ./scripts/dredd
+```
+
 ## License
 
 polls-api is released under the MIT license. See [LICENSE](LICENSE).


### PR DESCRIPTION
- Mention that pip and virtualenv are prerequisites along with linking to their installation pages.
- Include instructions to run dredd.