### PR TITLE
Support vnd.hal+json content type

### DIFF
--- a/polls/resource.py
+++ b/polls/resource.py
@@ -55,6 +55,7 @@ class Resource(View):
         return {
             'application/json': to_json,
             'application/hal+json': to_hal,
+            'application/vnd.hal+json': to_hal,
             'application/vnd.siren+json': to_siren,
         }
 
@@ -84,6 +85,7 @@ class Resource(View):
         acceptable = (
             AcceptParameters(ContentType('application/json')),
             AcceptParameters(ContentType('application/hal+json')),
+            AcceptParameters(ContentType('application/vnd.hal+json')),
             AcceptParameters(ContentType('application/vnd.siren+json')),
         )
 


### PR DESCRIPTION
Since the specification for HAL is registered with IANA, it should therefore support the IANA assigned content type, including the `vnd.` prefix.

- http://www.iana.org/assignments/media-types/application/vnd.hal+json
- http://www.iana.org/assignments/media-types/application/vnd.hal+xml
