### PR TITLE
Rearrange order of sections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,48 +8,6 @@ view polls and vote in them. Take a look at the
 [API Documentation](http://docs.pollsapi.apiary.io/). We've
 deployed an instance of this [API](https://polls.apiblueprint.org/) for testing.
 
-## Deploying on Heroku using Docker
-
-**Requirements**:
-
-- [docker-machine](https://docs.docker.com/machine/)
-- [docker-compose](https://docs.docker.com/compose/)
-
-### Heroku Docker plugin
-
-`heroku plugins:install heroku-docker`
-
-### Running the development server in Docker
-
-`docker-compose up web`
-
-`open "http://$(docker-machine ip default):8080"`
-
-### Running tests in Docker
-
-`docker-compose run shell python manage.py test`
-
-### Release new version to Heroku
-
-`heroku docker:release`
-
-## Deploying on Heroku
-
-Click the button below to automatically set up the Polls API in an app
-running on your Heroku account.
-
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/apiaryio/polls-api)
-
-Once you've deployed, you can easily clone the application and alter the
-configuration to disable features:
-
-```bash
-$ heroku clone -a new-app-name
-$ heroku config:set POLLS_CAN_VOTE_QUESTION=false
-$ heroku config:set POLLS_CAN_CREATE_QUESTION=false
-$ heroku config:set POLLS_CAN_DELETE_QUESTION=false
-```
-
 ## Development Environment
 
 You can configure a development environment with the following:
@@ -82,6 +40,57 @@ installed, you can run the following to run dredd against the Polls API:
 
 ```bash
 $ ./scripts/dredd
+```
+
+## Deploying on Heroku
+
+Click the button below to automatically set up the Polls API in an app
+running on your Heroku account.
+
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/apiaryio/polls-api)
+
+Once you've deployed, you can easily clone the application and alter the
+configuration to disable features:
+
+```bash
+$ heroku clone -a new-app-name
+$ heroku config:set POLLS_CAN_VOTE_QUESTION=false
+$ heroku config:set POLLS_CAN_CREATE_QUESTION=false
+$ heroku config:set POLLS_CAN_DELETE_QUESTION=false
+```
+
+### Deploying on Heroku using Docker
+
+If you'd like to, you may use Docker on Heroku instead.
+
+**Requirements**:
+
+- [docker-machine](https://docs.docker.com/machine/)
+- [docker-compose](https://docs.docker.com/compose/)
+
+#### Heroku Docker plugin
+
+```
+heroku plugins:install heroku-docker`
+```
+
+#### Running the development server in Docker
+
+```
+docker-compose up web
+open "http://$(docker-machine ip default):8080"
+```
+
+#### Running tests in Docker
+
+```
+docker-compose run shell python manage.py test
+```
+
+#### Release new version to Heroku
+
+```
+heroku docker:release
 ```
 
 ## License


### PR DESCRIPTION
This pull request changes the order of the sections to move the docker Heroku instructions to the bottom of the README. The Heroku button and simpler instructions have been moved above the docker instructions. I don't think we should be putting docker right at the top as this alternate installation instructions are far more complicated than the simple Heroku button ones. We should keep this simple for the average user who probably doesn't want to play around with the Polls API in docker.

I've also moved running the local development environment higher in the README above the instructions to deploy to Heroku. I believe people will probably want to play around with it locally before deploying it elsewhere and these instructions are more important.