### PR TITLE
Disable collect static in Python buildpack

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,7 +17,8 @@
   "env": {
     "POLLS_CAN_CREATE_QUESTION": "true",
     "POLLS_CAN_DELETE_QUESTION": "true",
-    "POLLS_CAN_VOTE_QUESTION": "true"
+    "POLLS_CAN_VOTE_QUESTION": "true",
+    "DISABLE_COLLECTSTATIC": "1"
   },
   "image": "heroku/python"
 }


### PR DESCRIPTION
The Python build pack has started, by default running `python manage.py collectstatic` for all Django apps, even if they don't use the collectstatic Django app (which we don't). This causes the Heroku button to fail since it runs collectstatic which isn't used.

```
     $ python manage.py collectstatic --noinput
       Unknown command: 'collectstatic'
       Type 'manage.py help' for usage.
 !     Error while running '$ python manage.py collectstatic --noinput'.
       See traceback above for details.
       You may need to update application code to resolve this error.
       Or, you can disable collectstatic for this application:
          $ heroku config:set DISABLE_COLLECTSTATIC=1
       http://devcenter.heroku.com/articles/django-assets
 !     Push rejected, failed to compile Python app
```

This pull request disables it entirely.

/cc @abtris 