### PR TITLE
Remove django-toolbelt dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ certifi==2015.04.28
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-cors-headers==1.0.0
-django-toolbelt==0.0.1
 future==0.14.3
 gunicorn==19.2.1
 ldclient-py==0.16.2


### PR DESCRIPTION
This is a code-less dependency that just depends on other dependencies.
Unfortunately it doesn't have a defined license so we must remove it.

Dependencies:

- [ ] https://github.com/apiaryio/polls-api/pull/41