### PR TITLE
Revert "Make dredd runner compatible with docker image"

### DIFF
--- a/scripts/dredd
+++ b/scripts/dredd
@@ -17,6 +17,6 @@ $DOCKER_COMPOSE run -e DATABASE_URL=sqlite:///dredd.sqlite shell "python manage.
 $DOCKER_COMPOSE up -d web
 IPWEB=`docker ps  | grep pollsapi_web | cut -d ' ' -f1 | xargs docker inspect  | grep IPAddress\": | cut -d ":" -f2 | tr -d "\"" | tr -d "," | tr -d '[[:space:]]'`
 # Run dredd
-docker run -v $(pwd):/root -w /root apiaryio/dredd /node_modules/.bin/dredd apiary.apib http://$IPWEB:8080
+docker run -v $(pwd):/root -w /root apiaryio/dredd dredd apiary.apib http://$IPWEB:8080
 RESULT=$?
 exit $RESULT


### PR DESCRIPTION
Reverts apiaryio/polls-api#41

Since #41 was created, https://github.com/apiaryio/docker-base-images/pull/60 was also merged solving the problem upstream in the Docker image.