### PR TITLE
Return 404 instead of 500 for not found

### DIFF
--- a/polls/resource.py
+++ b/polls/resource.py
@@ -2,8 +2,8 @@ import json
 from collections import namedtuple
 
 from django.views.generic import View
-from django.http import HttpResponse
-from django.core.paginator import Paginator
+from django.http import Http404, HttpResponse
+from django.core.paginator import Paginator, EmptyPage
 from django.utils.cache import patch_cache_control, patch_vary_headers
 
 from negotiator import ContentType, ContentNegotiator, AcceptParameters
@@ -135,7 +135,12 @@ class CollectionResource(Resource):
 
     def get_relations(self):
         paginator = self.get_paginator()
-        page = paginator.page(int(self.request.GET.get('page', 1)))
+
+        try:
+            page = paginator.page(int(self.request.GET.get('page', 1)))
+        except EmptyPage:
+            raise Http404()
+
         objects = page.object_list
         relations = {
             self.relation: self.get_resources(page)

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -19,6 +19,16 @@ class ResourceTestCase(TestCase):
         self.assertEqual(response['Allow'], 'HEAD, GET, DELETE')
 
 
+class QuestionListTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_unfound_page(self):
+        response = self.client.get('/questions?page=5')
+
+        self.assertEqual(response.status_code, 404)
+
+
 class CreateQuestionTestCase(TestCase):
     def setUp(self):
         self.client = Client()
@@ -66,6 +76,9 @@ class CreateQuestionTestCase(TestCase):
 
 
 class QuestionDetailTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+
     def test_choices_ordered_by_votes_then_alphabetical(self):
         question = Question.objects.create(question_text='Are choices ordered correctly?')
         yes_choice = Choice.objects.create(question=question, choice_text='Yes')
@@ -80,3 +93,8 @@ class QuestionDetailTestCase(TestCase):
 
         yes_choice.vote()
         self.assertEqual(get_choices(), [yes_choice, no_choice])
+
+    def test_unfound_page(self):
+        response = self.client.get('/questions/1337')
+
+        self.assertEqual(response.status_code, 404)

--- a/polls/views.py
+++ b/polls/views.py
@@ -1,7 +1,8 @@
 import json
 
 from django.db.models import Count
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
+from django.core.paginator import EmptyPage
 
 from polls.models import Question, Choice, Vote
 from polls.resource import Action, Attribute, Resource, CollectionResource, SingleObjectMixin
@@ -55,6 +56,14 @@ class QuestionResource(Resource, SingleObjectMixin):
             actions['delete'] = Action(method='DELETE', attributes=None)
 
         return actions
+
+    def get(self, *args, **kwargs):
+        try:
+            self.get_object()
+        except self.model.DoesNotExist:
+            raise Http404()
+
+        return super(QuestionResource, self).get(*args, **kwargs)
 
     def delete(self, request, *args, **kwargs):
         if not can_delete_question(self.get_object(), request):


### PR DESCRIPTION
Unknown page `GET /questions?page=10000` and questions that don't exist `GET /question/10000` would cause unhandled errors and return 500 error to a user. This PR adds handling and returns a 404 in these cases.