### PR TITLE
Update location to initial data in cleanup command

### DIFF
--- a/polls/management/commands/cleanup.py
+++ b/polls/management/commands/cleanup.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
     help = 'Removes questions older than an hour except initial data'
 
     def handle(self, *args, **kwargs):
-        with open('initial_data.json') as fp:
+        with open('polls/fixtures/initial_data.json') as fp:
             initial_data = json.load(fp)
 
         initial_questions = filter(lambda m: m['model'] == 'polls.question', initial_data)


### PR DESCRIPTION
When I updated to Django 1.9 in #42, the location of the fixture changed due to changes in Django 1.9. The cleanup script was never updated and thus fails when ran:

```
$ heroku run python manage.py cleanup -a pollsapi
 ▸    heroku-cli: update available from 6.13.4 to 6.14.39-addc925
Running python manage.py cleanup on ⬢ pollsapi... up, run.9999 (Standard-1X)
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/management/__init__.py", line 367, in execute_from_command_line
    utility.execute()
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/management/__init__.py", line 359, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/management/base.py", line 294, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/management/base.py", line 345, in execute
    output = self.handle(*args, **options)
  File "/app/polls/management/commands/cleanup.py", line 13, in handle
    with open('initial_data.json') as fp:
IOError: [Errno 2] No such file or directory: 'initial_data.json'
```