### PR TITLE
Remove launch darkly

### DIFF
--- a/polls/features.py
+++ b/polls/features.py
@@ -2,17 +2,7 @@ import os
 import json
 from hashlib import sha1
 
-try:
-    from ldclient import LDClient
-except ImportError:
-    LDClient = None
-
 from polls.settings import CAN_CREATE_QUESTION, CAN_DELETE_QUESTION, CAN_VOTE_QUESTION
-
-if LDClient and 'LD_API_KEY' in os.environ:
-    ld_client = LDClient(os.environ['LD_API_KEY'])
-else:
-    ld_client = None
 
 
 with open('polls/fixtures/initial_data.json') as fp:
@@ -22,12 +12,6 @@ initial_question_pks = map(lambda m: m['pk'], initial_questions)
 
 
 def is_feature_enabled(feature_key, request, default=False):
-    if ld_client:
-        ip_address = request.META.get('REMOTE_ADDR', 'unknown')
-        key = sha1(ip_address).hexdigest()
-        user = {'key': key}
-        return ld_client.toggle(feature_key, user, default)
-
     return default
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ Django==1.10.5
 django-cors-headers==1.1.0
 future==0.14.3
 gunicorn==19.2.1
-ldclient-py==0.16.2
 negotiator==1.0.0
 psycopg2==2.6
 requests==2.4.0


### PR DESCRIPTION
Launch Darkly is unused and undocumented and for maintainability can be
removed.

The previously used version no longer works with pip10.