### PR TITLE
Validate entire request body when creating questions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ requests = "==2.4.0"
 "static3" = "==0.5.1"
 Django = "==1.11.13"
 "psycopg2" = "*"
+jsonschema = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8df9f90ef28425f9a4064705d808bef26cdabbaf2155ec38d4fac81bbcf3ebbb"
+            "sha256": "2d9d69782c6788894b0681e228e1fb82db8400d42500e58e8ee6ed84daac240f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -53,6 +53,14 @@
             "index": "pypi",
             "version": "==1.1.0"
         },
+        "functools32": {
+            "hashes": [
+                "sha256:89d824aa6c358c421a234d7f9ee0bd75933a67c29588ce50aaa3acdf4d403fa0",
+                "sha256:f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d"
+            ],
+            "markers": "python_version == '2.7'",
+            "version": "==3.2.3.post2"
+        },
         "future": {
             "hashes": [
                 "sha256:62857d51881d97dd5492b9295b9f51d92108a52a4c88e2c40054c1d3e5995be9"
@@ -67,6 +75,14 @@
             ],
             "index": "pypi",
             "version": "==19.2.1"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08",
+                "sha256:6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02"
+            ],
+            "index": "pypi",
+            "version": "==2.6.0"
         },
         "negotiator": {
             "hashes": [
@@ -110,10 +126,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555",
-                "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
+                "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
+                "sha256:ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"
             ],
-            "version": "==2018.4"
+            "version": "==2018.5"
         },
         "requests": {
             "hashes": [

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -76,6 +76,26 @@ class CreateQuestionTestCase(TestCase):
         self.assertEqual(response2.status_code, 201)
         self.assertEqual(len(Question.objects.all()), original_question_count + 2)
 
+    def test_creating_question_without_body(self):
+        response = self.client.post('/questions',  content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_creating_question_with_invalid_question(self):
+        response = self.client.post('/questions', '{"question": null, "choices": ["A", "B"]}', content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_creating_question_with_invalid_choices(self):
+        response = self.client.post('/questions', '{"question": "Test Question?", "choices": ["A", "B", null]}', content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_creating_question_with_few_choices(self):
+        response = self.client.post('/questions', '{"question": "Test Question?", "choices": ["A"]}', content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+
 
 class QuestionDetailTestCase(TestCase):
     def setUp(self):


### PR DESCRIPTION
Some invalid inputs such as incorrect data types caused 500 errors due to invalid input into database.

I'm using jsonschema to achieve this, the jsonschema 2.6.0 library has approval in TPLTA