### PR TITLE
Return 404 when voting for a choice that doesnt exist

### DIFF
--- a/polls/tests.py
+++ b/polls/tests.py
@@ -151,3 +151,23 @@ class ChoiceDetailTestCase(TestCase):
         response = self.client.get('/questions/100/choices/1')
 
         self.assertEqual(response.status_code, 404)
+
+    def test_vote_choice(self):
+        question = Question.objects.create(question_text='Testing Question?')
+        choice = Choice.objects.create(question=question, choice_text='Best Choice')
+
+        path = '/questions/{}/choices/{}'.format(question.pk, choice.pk)
+
+        response = self.client.post(path)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(json.loads(response.content), {
+            'url': path,
+            'choice': 'Best Choice',
+            'votes': 1
+        })
+
+    def test_vote_unknown_choice(self):
+        response = self.client.post('/questions/1/choices/5')
+
+        self.assertEqual(response.status_code, 404)

--- a/polls/views.py
+++ b/polls/views.py
@@ -112,7 +112,12 @@ class ChoiceResource(Resource, SingleObjectMixin):
         if not can_vote_choice(self.request):
             return self.http_method_not_allowed(request)
 
-        self.get_object().vote()
+        try:
+            choice = self.get_object()
+        except self.model.DoesNotExist:
+            raise Http404('Choice does not exist')
+
+        choice.vote()
         response = self.get(request)
         response.status_code = 201
         return response


### PR DESCRIPTION
When a user votes for a choice that doesn't exist, before a DoesNotExist exception was being raised causing a 500. This should be caught and return a 404 to the user.