### PR TITLE
Fix incorrect working directory in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 web:
   build: .
   command: 'gunicorn polls.wsgi --log-file -'
-  working_dir: /app/user
+  working_dir: /usr/src/app
   environment:
     PORT: 8080
     DATABASE_URL: 'postgres://postgres:@herokuPostgresql:5432/postgres'


### PR DESCRIPTION
In prior pull requests the working directory in Dockerfile became inconsistent with docker-compose.yaml and thus when you run a command in docker-compose the wd is incorrect and prevents you running the application.