### PR TITLE
Handle accept header without subtype

### DIFF
--- a/dredd.yml
+++ b/dredd.yml
@@ -1,4 +1,3 @@
-language: python
 server: python manage.py runserver
 server-wait: 3
 color: true

--- a/polls/resource.py
+++ b/polls/resource.py
@@ -96,7 +96,12 @@ class Resource(View):
 
         negotiator = ContentNegotiator(acceptable[0], acceptable)
         accept = request.META.get('HTTP_ACCEPT')
-        negotiated_type = negotiator.negotiate(accept=request.META.get('HTTP_ACCEPT'))
+
+        try:
+            negotiated_type = negotiator.negotiate(accept=request.META.get('HTTP_ACCEPT'))
+        except ValueError:
+            negotiated_type = None
+
         if negotiated_type:
             return negotiated_type.content_type
 

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -20,6 +20,16 @@ class ResourceTestCase(TestCase):
 
         self.assertEqual(response['Allow'], 'HEAD, GET, DELETE')
 
+    def test_invalid_accept_header(self):
+        class TestResource(Resource):
+            pass
+
+        request = HttpRequest()
+        request.META['HTTP_ACCEPT'] = 'application'
+        response = TestResource().get(request)
+
+        self.assertEqual(response.status_code, 200)
+
 
 class QuestionListTestCase(TestCase):
     def setUp(self):


### PR DESCRIPTION
When the accept header doesn't contain a sub-type negotiatior will raise a ValueError resulting in a 500 status. For example:

```
$ curl http://127.0.0.1:8000/ -H 'Accept: application'
<h1>Server Error (500)</h1>
```

```
Internal Server Error: /
Traceback (most recent call last):
  File "/Users/kyle/.local/share/virtualenvs/polls-api-n-94SdNq/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/Users/kyle/.local/share/virtualenvs/polls-api-n-94SdNq/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/Users/kyle/.local/share/virtualenvs/polls-api-n-94SdNq/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/Users/kyle/.local/share/virtualenvs/polls-api-n-94SdNq/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/kyle/.local/share/virtualenvs/polls-api-n-94SdNq/lib/python2.7/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/kyle/.local/share/virtualenvs/polls-api-n-94SdNq/lib/python2.7/site-packages/django/views/generic/base.py", line 88, in dispatch
    return handler(request, *args, **kwargs)
  File "/Users/kyle/Projects/apiaryio/polls-api/polls/resource.py", line 65, in get
    content_type = self.determine_content_type(request)
  File "/Users/kyle/Projects/apiaryio/polls-api/polls/resource.py", line 100, in determine_content_type
    negotiated_type = negotiator.negotiate(accept=request.META.get('HTTP_ACCEPT'))
  File "/Users/kyle/.local/share/virtualenvs/polls-api-n-94SdNq/lib/python2.7/site-packages/negotiator/negotiator.py", line 423, in negotiate
    accept_analysed = self._analyse_accept(accept)
  File "/Users/kyle/.local/share/virtualenvs/polls-api-n-94SdNq/lib/python2.7/site-packages/negotiator/negotiator.py", line 558, in _analyse_accept
    supertype, subtype = type.split("/", 1)
ValueError: need more than 1 value to unpack
```

---

I've also discovered that CI is failing now, appears to be due to a regression in Dredd:

```
Python hooks handler command not found: dredd-hooks-python
Install python hooks handler by running:
$ pip install dredd_hooks
```

When language Python is set, Dredd requires `dredd_hooks` to be installed (despite having no hooks). Appears to be a regression, I've removed `language: python` from the Dredd config.