### PR TITLE
Update to Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 aliases:
   - &pollsapi-image
-    image: circleci/python:2.7.15
+    image: circleci/python:3.7
     environment:
       DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
       PORT: 8000
@@ -44,7 +44,7 @@ jobs:
   test-dredd:
     docker:
       - <<: *pollsapi-image
-        image: circleci/python:2.7.15-node-browsers
+        image: circleci/python:3.7-node-browsers
       - <<: *database-image
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:3.7
 
 RUN pip install pipenv
 WORKDIR /usr/src/app

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 dj-database-url = "*"
 django-cors-headers = "*"
 gunicorn = ">=19.5.0"
-Django = ">=1.11.15"
+Django = "==1.11.21"
 jsonschema = "*"
 psycopg2-binary = "*"
 python-mimeparse = "*"
@@ -15,4 +15,4 @@ python-mimeparse = "*"
 [dev-packages]
 
 [requires]
-python_version = "2.7"
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5c239a82fbf1cbedf8f2e66fe683d378fb7216a5b424185b45b28371c8cbde7e"
+            "sha256": "4785421f1f8dfeead102143abe329c59db0c16c780960e95577d7617539b7eff"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "2.7"
+            "python_version": "3.7"
         },
         "sources": [
             {
@@ -46,14 +46,6 @@
             ],
             "index": "pypi",
             "version": "==3.0.2"
-        },
-        "functools32": {
-            "hashes": [
-                "sha256:89d824aa6c358c421a234d7f9ee0bd75933a67c29588ce50aaa3acdf4d403fa0",
-                "sha256:f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d"
-            ],
-            "markers": "python_version < '3'",
-            "version": "==3.2.3.post2"
         },
         "gunicorn": {
             "hashes": [

--- a/polls/resource.py
+++ b/polls/resource.py
@@ -75,13 +75,13 @@ class Resource(View):
             can_embed_relation = lambda relation: not self.can_embed(relation[0])
             relations = filter(can_embed_relation, self.get_relations().items())
             relation_to_link = lambda relation: '<{}>; rel="{}"'.format(relation[1].get_uri(), relation[0])
-            links = map(relation_to_link, relations)
+            links = list(map(relation_to_link, relations))
             if len(links) > 0:
                 response['Link'] = ', '.join(links)
 
         if str(content_type) != 'application/vnd.siren+json':
             # Add an Allow header
-            methods = ['HEAD', 'GET'] + map(lambda a: a.method, self.get_actions().values())
+            methods = ['HEAD', 'GET'] + list(map(lambda a: a.method, self.get_actions().values()))
             response['allow'] = ', '.join(methods)
 
         return response
@@ -134,7 +134,7 @@ class CollectionResource(Resource):
             resource.request = self.request
             return resource
 
-        return map(to_resource, objects)
+        return list(map(to_resource, objects))
 
     def get_relations(self):
         paginator = self.get_paginator()
@@ -170,7 +170,7 @@ class CollectionResource(Resource):
         def json_handler(resource):
             relations = self.get_relations()
         handlers = super(CollectionResource, self).content_handlers()
-        handlers['application/json'] = lambda resource: map(to_json, self.get_relations()[self.relation])
+        handlers['application/json'] = lambda resource: list(map(to_json, self.get_relations()[self.relation]))
         return handlers
 
     def can_embed(self, relation):
@@ -184,10 +184,10 @@ def to_json(resource):
     for relation, related_resource in resource.get_relations().items():
         if isinstance(related_resource, list):
             if resource.can_embed(relation):
-                document[relation] = map(to_json, related_resource)
+                document[relation] = list(map(to_json, related_resource))
             else:
-                document[relation] = map(lambda r: {'url': r.get_uri()},
-                                         related_resource)
+                document[relation] = list(map(lambda r: {'url': r.get_uri()},
+                                         related_resource))
         else:
             if resource.can_embed(relation):
                 document[relation] = to_json(related_resource)
@@ -209,7 +209,7 @@ def to_hal(resource):
 
         if resource.can_embed(relation) or isinstance(related_resource, list):
             if isinstance(related_resource, list):
-                embed[relation] = map(to_hal, related_resource)
+                embed[relation] = list(map(to_hal, related_resource))
             else:
                 embed[relation] = to_hal(related_resource)
         else:
@@ -250,13 +250,13 @@ def to_siren(resource):
     for relation, related_resource in resource.get_relations().items():
         if resource.can_embed(relation):
             if isinstance(related_resource, list):
-                entities += map(to_siren_relation(relation), related_resource)
+                entities += list(map(to_siren_relation(relation), related_resource))
             else:
                 entity = to_siren_relation(relation)(related_resource)
                 entities.append(entity)
         else:
             if isinstance(related_resource, list):
-                items = map(to_siren_link(relation), related_resource)
+                items = list(map(to_siren_link(relation), related_resource))
                 links += items
             else:
                 links.append(to_siren_link(relation)(related_resource))
@@ -284,7 +284,7 @@ def to_siren(resource):
                     'type': attribute.category,
                     'title': attribute.name.capitalize(),
                 }
-            action_dict['fields'] = map(to_field, action.attributes)
+            action_dict['fields'] = list(map(to_field, action.attributes))
 
         actions.append(action_dict)
 

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -119,7 +119,7 @@ class QuestionDetailTestCase(TestCase):
         resource.obj = question
 
         def get_choices():
-            return map(lambda r: r.obj, resource.get_relations()['choices'])
+            return list(map(lambda r: r.obj, resource.get_relations()['choices']))
 
         self.assertEqual(get_choices(), [no_choice, yes_choice])
 

--- a/polls/views.py
+++ b/polls/views.py
@@ -47,7 +47,7 @@ class QuestionResource(Resource, SingleObjectMixin):
             return resource
 
         return {
-            'choices': map(choice_resource, list(choices)),
+            'choices': list(map(choice_resource, choices)),
         }
 
     def get_actions(self):
@@ -200,7 +200,7 @@ class QuestionCollectionResource(CollectionResource):
             question = None
 
         if question:
-            choices = map(lambda c: c.choice_text, question.choices.order_by('choice_text'))
+            choices = list(map(lambda c: c.choice_text, question.choices.order_by('choice_text')))
             if choices == sorted(choice_texts):
                 return (question, False)
 


### PR DESCRIPTION
Most change in diff will be wrapping `map` result in `list`, in Python 3 map returns a generator instead of a list.