### PR TITLE
Add /healthcheck

### DIFF
--- a/polls/tests.py
+++ b/polls/tests.py
@@ -181,3 +181,17 @@ class ChoiceDetailTestCase(TestCase):
         response = self.client.post('/questions/1/choices/5')
 
         self.assertEqual(response.status_code, 404)
+
+
+class HealthCheckTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_healthy(self):
+        response = self.client.get('/healthcheck')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/health+json')
+        self.assertEqual(json.loads(response.content), {
+            'status': 'ok',
+        })

--- a/polls/urls.py
+++ b/polls/urls.py
@@ -1,6 +1,11 @@
 from django.urls import path
+from django.http import JsonResponse
 from polls.views import (RootResource, QuestionCollectionResource,
                          QuestionResource, ChoiceResource)
+
+
+def healthcheck_view(request):
+    return JsonResponse({ 'status': 'ok' }, content_type='application/health+json')
 
 
 def error_view(request):
@@ -12,5 +17,6 @@ urlpatterns = [
     path('questions', QuestionCollectionResource.as_view()),
     path('questions/<int:pk>', QuestionResource.as_view()),
     path('questions/<int:question_pk>/choices/<int:pk>', ChoiceResource.as_view()),
+    path('healthcheck', healthcheck_view),
     path('500', error_view),
 ]


### PR DESCRIPTION
The API returns the stauts of the API, which is always healthy if the success made it through. This follows the design of RFC 8259 (https://health15.docs.apiary.io/#reference/0/health-check/health-check)