### PR TITLE
Allow cleanup script to delete votes

### DIFF
--- a/polls/management/commands/cleanup.py
+++ b/polls/management/commands/cleanup.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 import json
 
 from django.core.management.base import BaseCommand, CommandError
-from polls.models import Question
+from polls.models import Question, Vote
 
 
 class Command(BaseCommand):
@@ -19,5 +19,10 @@ class Command(BaseCommand):
         qs = Question.objects.exclude(id__in=initial_question_pks).filter(published_at__lt=one_hour_ago)
 
         print('Deleting {} questions'.format(qs.count()))
+        qs.delete()
+
+        qa = Vote.objects.all()
+
+        print('Deleting {} votes'.format(qs.count()))
         qs.delete()
 


### PR DESCRIPTION
The cleanup script deletes all the non-fixture questions, however it still leaves around potentially tens of thousands of votes on the fixture questions.

This changeset adds an additional step to the cleanup script to remove all votes.

```
>>> Vote.objects.count()
33304
```