### PR TITLE
Add X-Frame-Options header as per OWASP report

### DIFF
--- a/polls/settings.py
+++ b/polls/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.cache.UpdateCacheMiddleware',
     'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
     'django.middleware.security.SecurityMiddleware',
@@ -127,6 +128,8 @@ CAN_DELETE_QUESTION = get_env('POLLS_CAN_DELETE_QUESTION')
 # Enables the ability to vote on a question
 CAN_VOTE_QUESTION = get_env('POLLS_CAN_VOTE_QUESTION')
 
+
+X_FRAME_OPTIONS = 'DENY'
 
 # CORS Headers
 


### PR DESCRIPTION
This changeset adds the following header:

```
X-Frame-Options: DENY
```

As part of OWASP secure headers where the absence of this header can failing report (https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#tab=Headers).

> The page cannot be displayed in a frame, regardless of the site attempting to do so. 