### PR TITLE
Return 404 when page is not a number

### DIFF
--- a/polls/resource.py
+++ b/polls/resource.py
@@ -140,7 +140,12 @@ class CollectionResource(Resource):
         paginator = self.get_paginator()
 
         try:
-            page = paginator.page(int(self.request.GET.get('page', 1)))
+            page_number = int(self.request.GET.get('page', 1))
+        except ValueError:
+            raise Http404()
+
+        try:
+            page = paginator.page(page_number)
         except EmptyPage:
             raise Http404()
 

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -49,6 +49,11 @@ class QuestionListTestCase(TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_non_numeric_page(self):
+        response = self.client.get('/questions?page=one', secure=True)
+
+        self.assertEqual(response.status_code, 404)
+
 
 class CreateQuestionTestCase(TestCase):
     def setUp(self):


### PR DESCRIPTION
The code would throw a ValueError (since a string isn't number) and result in a 500.