### PR TITLE
Return 404 when deleting unknown question

### DIFF
--- a/polls/tests.py
+++ b/polls/tests.py
@@ -187,6 +187,17 @@ class QuestionDetailTestCase(TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_deleting_question(self):
+        question = Question.objects.create(question_text='Can I delete a question?')
+        response = self.client.delete('/questions/{}'.format(question.pk), secure=True)
+
+        self.assertEqual(response.status_code, 204)
+
+    def test_deleting_unknown_question(self):
+        response = self.client.delete('/questions/1234', secure=True)
+
+        self.assertEqual(response.status_code, 404)
+
 
 class ChoiceDetailTestCase(TestCase):
     def setUp(self):

--- a/polls/views.py
+++ b/polls/views.py
@@ -67,10 +67,15 @@ class QuestionResource(Resource, SingleObjectMixin):
         return super(QuestionResource, self).get(*args, **kwargs)
 
     def delete(self, request, *args, **kwargs):
-        if not can_delete_question(self.get_object(), request):
+        try:
+            question = self.get_object()
+        except self.model.DoesNotExist:
+            raise Http404()
+
+        if not can_delete_question(question, request):
             return self.http_method_not_allowed(request)
 
-        self.get_object().delete()
+        question.delete()
         return HttpResponse(status=204)
 
 


### PR DESCRIPTION
Failing test demonstrating problem, deleting a question raises `Question.DoesNotExist` which is not caught for the DELETE code path. To reproduce:

```
$ curl <service>/questions/1000000
```

```
$ python manage.py test
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
...............E.....
======================================================================
ERROR: test_unfound_page_delete (polls.tests.QuestionDetailTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kyle/Projects/apiaryio/polls-api/polls/tests.py", line 191, in test_unfound_page_delete
    response = self.client.delete('/questions/1', secure=True)
  File "/Users/kyle/Projects/apiaryio/polls-api/venv/lib/python3.8/site-packages/django/test/client.py", line 582, in delete
    response = super().delete(path, data=data, content_type=content_type, secure=secure, **extra)
  File "/Users/kyle/Projects/apiaryio/polls-api/venv/lib/python3.8/site-packages/django/test/client.py", line 395, in delete
    return self.generic('DELETE', path, data, content_type,
  File "/Users/kyle/Projects/apiaryio/polls-api/venv/lib/python3.8/site-packages/django/test/client.py", line 422, in generic
    return self.request(**r)
  File "/Users/kyle/Projects/apiaryio/polls-api/venv/lib/python3.8/site-packages/django/test/client.py", line 503, in request
    raise exc_value
  File "/Users/kyle/Projects/apiaryio/polls-api/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/Users/kyle/Projects/apiaryio/polls-api/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/Users/kyle/Projects/apiaryio/polls-api/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/kyle/Projects/apiaryio/polls-api/venv/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/kyle/Projects/apiaryio/polls-api/venv/lib/python3.8/site-packages/django/views/generic/base.py", line 97, in dispatch
    return handler(request, *args, **kwargs)
  File "/Users/kyle/Projects/apiaryio/polls-api/polls/views.py", line 70, in delete
    if not can_delete_question(self.get_object(), request):
  File "/Users/kyle/Projects/apiaryio/polls-api/polls/resource.py", line 21, in get_object
    self.obj = self.model.objects.get(pk=self.kwargs['pk'])
  File "/Users/kyle/Projects/apiaryio/polls-api/venv/lib/python3.8/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/kyle/Projects/apiaryio/polls-api/venv/lib/python3.8/site-packages/django/db/models/query.py", line 406, in get
    raise self.model.DoesNotExist(
polls.models.Question.DoesNotExist: Question matching query does not exist.

----------------------------------------------------------------------
Ran 21 tests in 0.120s

FAILED (errors=1)
```